### PR TITLE
add a loading status while generating snippets

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,7 +28,7 @@ const pickFolder = async (
   return selected.folder;
 };
 
-export const createDefaultConfiguration = (): void => {
+export const createConfigFile = (): void => {
   const folders = Workspace.workspaceFolders;
   if (!folders) {
     Window.showErrorMessage('A Synpet configuration can only be generated if VS Code is opened on a workspace folder.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
-import { window as Window, commands as Commands } from 'vscode';
+import { window as Window, commands as Commands, ProgressLocation } from 'vscode';
 import { trimEnd } from 'lodash';
 
 import { getComponentFiles, getVscodeCurrentPath, getVscodeCurrentFolder, getSnypetConfigSync } from './utils';
 import { SUPPORTED_FILE_TYPES, NO_CONFIG_ACTIONS } from './constants';
-import { createDefaultConfiguration } from './commands';
+import { createConfigFile } from './commands';
 
 import * as path from 'path';
 
@@ -12,83 +12,92 @@ import { parseComponents } from './component-parser';
 import { parseAtlaskit } from './atlaskit-parser';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  context.subscriptions.push(Commands.registerCommand('snypet.createConfig', createDefaultConfiguration));
+  context.subscriptions.push(Commands.registerCommand('snypet.createConfig', createConfigFile));
 
   const componentPath = getVscodeCurrentPath();
   const config = getSnypetConfigSync(componentPath);
 
   if (config && config.componentPath) {
-    const displayComments = config.displayComments || false;
-    const displayOptionalProps = config.optionalProps || false;
-    const componentFiles = await getComponentFiles();
-    if (!componentFiles.length) {
-      Window.showWarningMessage('No components found. Please verify the `componentPath` value in `snypet` config file');
-    }
-    let componentData = parseComponents(componentFiles) as any[];
+    Window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: 'Snypet🦜: Generating snippets...',
+        cancellable: false,
+      },
+      async () => {
+        const { displayComments = false, optionalProps = false } = config;
+        const componentFiles = await getComponentFiles();
+        if (!componentFiles.length) {
+          Window.showWarningMessage(
+            'No components found. Please verify the `componentPath` value in `snypet` config file'
+          );
+        }
+        let componentData = parseComponents(componentFiles) as any[];
 
-    const { componentPath } = config;
-    const ATLASKIT_PATH = 'node_modules/@atlaskit';
-    // TODO: remove hardcoded atlaskit before publishing
-    if (componentPath.includes(ATLASKIT_PATH)) {
-      const atlasKitRoot: string = path.join(getVscodeCurrentPath(), ATLASKIT_PATH);
-      const akData = parseAtlaskit(atlasKitRoot);
-      componentData = componentData.concat(akData);
-    }
-
-    componentData.forEach((component: any) => {
-      component.attr = '';
-      const componentPropTypeDefs = component.propTypeDef;
-      if (Array.isArray(componentPropTypeDefs)) {
-        const attrs = componentPropTypeDefs.reduce((acc, prop, index) => {
-          let comment = prop.type
-            .replace(/\s\s+/g, ' ')
-            .replace(/'|"|`|{|}/g, '')
-            .replace(/\r?\n|\r/g, '');
-
-          if (prop.hasQuestionToken && !displayOptionalProps) {
-            return acc;
-          }
-
-          if (prop.hasQuestionToken && displayComments) {
-            comment += ' ? ';
-          }
-
-          if (prop.comment && displayComments) {
-            comment += ` //${prop.comment
-              .replace(/\s\s+/g, ' ')
-              .replace(/'|"|`|{|}/g, '')
-              .replace(/\r?\n|\r/g, '')}`;
-          }
-
-          const attributes = `${acc}\n\t${prop.name}='$\{${index + 1}:${trimEnd(comment, ';')}}'`;
-          return attributes;
-        }, '');
-        component.attr = attrs;
-      }
-    });
-
-    const provider = vscode.languages.registerCompletionItemProvider(SUPPORTED_FILE_TYPES, {
-      provideCompletionItems() {
-        const items: vscode.CompletionItem[] = [];
+        const { componentPath } = config;
+        const ATLASKIT_PATH = 'node_modules/@atlaskit';
+        // TODO: remove hardcoded atlaskit before publishing
+        if (componentPath.includes(ATLASKIT_PATH)) {
+          const atlasKitRoot: string = path.join(getVscodeCurrentPath(), ATLASKIT_PATH);
+          const akData = parseAtlaskit(atlasKitRoot);
+          componentData = componentData.concat(akData);
+        }
 
         componentData.forEach((component: any) => {
-          let snippetName = component.componentName;
-          if (config.prefix) {
-            snippetName = `${config.prefix}${snippetName}`;
-          }
-          const snippetCompletion = new vscode.CompletionItem(snippetName);
-          snippetCompletion.insertText = new vscode.SnippetString(
-            `<${component.componentName}${component.attr}>\n</${component.componentName}>`
-          );
+          component.attr = '';
+          const componentPropTypeDefs = component.propTypeDef;
+          if (Array.isArray(componentPropTypeDefs)) {
+            const attrs = componentPropTypeDefs.reduce((acc, prop, index) => {
+              let comment = prop.type
+                .replace(/\s\s+/g, ' ')
+                .replace(/'|"|`|{|}/g, '')
+                .replace(/\r?\n|\r/g, '');
 
-          items.push(snippetCompletion);
+              if (prop.hasQuestionToken && !optionalProps) {
+                return acc;
+              }
+
+              if (prop.hasQuestionToken && displayComments) {
+                comment += ' ? ';
+              }
+
+              if (prop.comment && displayComments) {
+                comment += ` //${prop.comment
+                  .replace(/\s\s+/g, ' ')
+                  .replace(/'|"|`|{|}/g, '')
+                  .replace(/\r?\n|\r/g, '')}`;
+              }
+
+              const attributes = `${acc}\n\t${prop.name}='$\{${index + 1}:${trimEnd(comment, ';')}}'`;
+              return attributes;
+            }, '');
+            component.attr = attrs;
+          }
         });
 
-        return items;
-      },
-    });
+        const provider = vscode.languages.registerCompletionItemProvider(SUPPORTED_FILE_TYPES, {
+          provideCompletionItems() {
+            const items: vscode.CompletionItem[] = [];
 
-    context.subscriptions.push(provider);
+            componentData.forEach((component: any) => {
+              let snippetName = component.componentName;
+              if (config.prefix) {
+                snippetName = `${config.prefix}${snippetName}`;
+              }
+              const snippetCompletion = new vscode.CompletionItem(snippetName);
+              snippetCompletion.insertText = new vscode.SnippetString(
+                `<${component.componentName}${component.attr}>\n</${component.componentName}>`
+              );
+
+              items.push(snippetCompletion);
+            });
+
+            return items;
+          },
+        });
+        context.subscriptions.push(provider);
+      }
+    );
   } else {
     const currentFolder = getVscodeCurrentFolder();
     let message = 'No Snypet configuration found. Would you like to add a config file?';


### PR DESCRIPTION
Snypet is slow right now so while it is parsing the components files and generating the snippet the editor could be unresponsive. Showing a progress bar would be better UX. 

![Kapture 2020-08-20 at 21 02 58](https://user-images.githubusercontent.com/4851763/90792868-a71b4280-e328-11ea-869c-8c2998677dad.gif)
